### PR TITLE
make bodyParser check for body attribute

### DIFF
--- a/src/lib/Transport/index.spec.ts
+++ b/src/lib/Transport/index.spec.ts
@@ -224,43 +224,68 @@ describe('Transport', () => {
       });
     });
 
-    it('should forward original JSON payload', (done) => {
-      const body = { name: 'json', message: 'should not get mutated' };
-      const req = new MockReq({
-        url: '/data/v1/valid',
-        method: 'POST',
-        headers: {
-          ...baseHeaders,
-          'Content-Type': 'application/json',
-        },
+    describe('parseBody', () => {
+      const jsonBody = JSON.stringify({
+        name: 'json',
+        message: 'should not get mutated',
+      });
+      const textBody = 'example,csv,string';
+      let req;
+
+      beforeEach(() => {
+        req = new MockReq({
+          url: '/data/v1/valid',
+          method: 'POST',
+          headers: baseHeaders,
+        });
       });
 
-      req.write(body);
-      req.end();
+      describe('with JSON body', () => {
+        beforeEach(() => {
+          req.headers['Content-Type'] = 'application/json';
+        });
 
-      client.build(req).then((options) => {
-        expect(options.body).to.deep.equal(JSON.stringify(body));
-        done();
+        it('should forward original body attribute', (done) => {
+          req.body = jsonBody;
+          req.end();
+          client.build(req).then((options) => {
+            expect(options.body).to.deep.equal(jsonBody);
+            done();
+          });
+        });
+
+        it('should forward original payload', (done) => {
+          req.write(JSON.parse(jsonBody));
+          req.end();
+          client.build(req).then((options) => {
+            expect(options.body).to.deep.equal(jsonBody);
+            done();
+          });
+        });
       });
-    });
 
-    it('should forward original Text payload', (done) => {
-      const body = 'example,csv,string';
-      const req = new MockReq({
-        url: '/data/v1/valid',
-        method: 'POST',
-        headers: {
-          ...baseHeaders,
-          'Content-Type': 'text/csv',
-        },
-      });
+      describe('with text body', () => {
+        beforeEach(() => {
+          req.headers['Content-Type'] = 'text/csv';
+        });
 
-      req.write(body);
-      req.end();
+        it('should forward original body attribute', (done) => {
+          req.body = textBody;
+          req.end();
+          client.build(req).then((options) => {
+            expect(options.body).to.deep.equal(textBody);
+            done();
+          });
+        });
 
-      client.build(req).then((options) => {
-        expect(options.body).to.deep.equal(body);
-        done();
+        it('should forward original payload', (done) => {
+          req.write(textBody);
+          req.end();
+          client.build(req).then((options) => {
+            expect(options.body).to.deep.equal(textBody);
+            done();
+          });
+        });
       });
     });
   });

--- a/src/lib/Transport/index.ts
+++ b/src/lib/Transport/index.ts
@@ -1,6 +1,7 @@
 import * as Promise from 'core-js/es6/promise';
 import * as Domo from 'ryuu-client';
 import * as request from 'request';
+import { Request } from 'express';
 import { IncomingMessage, IncomingHttpHeaders } from 'http';
 
 import { getMostRecentLogin } from '../utils';
@@ -143,6 +144,13 @@ export default class Transport {
   }
 
   private parseBody(req: IncomingMessage): Promise<string|void> {
+    // if body-parser was used before this middleware the "body" attribute will be set
+    const exprReq = req as Request;
+    if (typeof exprReq.body !== 'undefined') {
+      if (typeof exprReq.body === 'string') return Promise.resolve(exprReq.body);
+      return Promise.resolve(JSON.stringify(exprReq.body));
+    }
+
     return new Promise((resolve) => {
       const body = [];
 


### PR DESCRIPTION
It's possible that the express server consuming this middleware
has body-parser further "up" the stream. If so, we need to check
for a parsed body (which will either be a string or an object)